### PR TITLE
Add graphic.color override to Rectangle.cs

### DIFF
--- a/Assets/ThisOtherThing/UI Shapes Kit/Geometry/Shapes/Rectangle.cs
+++ b/Assets/ThisOtherThing/UI Shapes Kit/Geometry/Shapes/Rectangle.cs
@@ -7,7 +7,15 @@ namespace ThisOtherThing.UI.Shapes
 	[AddComponentMenu("UI/Shapes/Rectangle", 1)]
 	public class Rectangle : MaskableGraphic, IShape
 	{
-        	public override Color color { get => ShapeProperties.FillColor; set => ShapeProperties.FillColor = value; }
+		public override Color color
+		{
+		    get => ShapeProperties.FillColor;
+		    set
+		    {
+			ShapeProperties.FillColor = value;
+			SetVerticesDirty();
+		    }
+		}
 
 		public GeoUtils.OutlineShapeProperties ShapeProperties =
 			new GeoUtils.OutlineShapeProperties();

--- a/Assets/ThisOtherThing/UI Shapes Kit/Geometry/Shapes/Rectangle.cs
+++ b/Assets/ThisOtherThing/UI Shapes Kit/Geometry/Shapes/Rectangle.cs
@@ -7,6 +7,7 @@ namespace ThisOtherThing.UI.Shapes
 	[AddComponentMenu("UI/Shapes/Rectangle", 1)]
 	public class Rectangle : MaskableGraphic, IShape
 	{
+        	public override Color color { get => ShapeProperties.FillColor; set => ShapeProperties.FillColor = value; }
 
 		public GeoUtils.OutlineShapeProperties ShapeProperties =
 			new GeoUtils.OutlineShapeProperties();


### PR DESCRIPTION
Currently, Rectangle.color doesn't do anything, and code that operates on many graphics and modifies their color fails with Rectangle. This modification makes it do something.

Should probably be added to the other shapes too.